### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS migrated from dependabot reviewers
+*       @jessfraz


### PR DESCRIPTION
Dependabot is moving away from reviewers flag and CODEOWNERS should be used instead: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

This PR is people from dependabot.
